### PR TITLE
Display more details about termination checking

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -171,7 +171,7 @@
           </div>
           <div class="modal-body">
             <p>
-                Leon verifies the validity all the verification conditions found in the selected function.
+                Leon verifies the validity of all the verification conditions found in the selected function.
             </p>
             <div id="verifyProgress" class="progress">
               <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
@@ -188,6 +188,31 @@
                     </thead>
                     <tbody>
                     </tbody>
+                </table>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="terminationDialog" class="modal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+            <h3>Termination Checker</h3>
+          </div>
+          <div class="modal-body">
+            <p>
+                Leon checks if the selected function terminates for all inputs.
+            </p>
+            <div id="terminationProgress" class="progress">
+              <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
+            </div>
+            <div id="terminationResults">
+                <table class="allResults table table-hover">
                 </table>
             </div>
           </div>

--- a/app/workers/TerminationWorker.scala
+++ b/app/workers/TerminationWorker.scala
@@ -4,7 +4,6 @@ package workers
 import akka.actor._
 import play.api.libs.json._
 import play.api.libs.json.Json._
-
 import models._
 import leon.utils._
 import leon.termination._
@@ -14,19 +13,33 @@ import leon.purescala.Definitions._
 class TerminationWorker(val session: ActorRef, interruptManager: InterruptManager) extends Actor with WorkerActor {
   import ConsoleProtocol._
 
-  def notifyTerminOverview(cstate: CompilationState, data: Map[FunDef, TerminationGuarantee]) {
+  def tgToJson(fd: FunDef, tgo: Option[TerminationGuarantee]): JsValue = tgo match {
+    case Some(tg) => tg match {
+      case Terminates(reason) => toJson(Map(
+        "status" -> toJson("terminates")
+      ))
+      case LoopsGivenInputs(reason, args) => toJson(Map(
+        "status" -> toJson("loopsfor"),
+        "call" -> toJson(args.mkString(fd.id+"(", ",", ")"))
+      ))
+      case CallsNonTerminating(funs) => toJson(Map(
+        "status" -> toJson("callsnonterminating"),
+        "calls" -> toJson(funs.map(_.id.name))
+      ))
+      case _ => toJson(Map(
+        "status" -> toJson("noguarantee")
+      ))
+    }
+    case None => toJson(Map(
+      "status" -> toJson("wip") // "work in progress", will display spinning arrows
+    ))
+  }
+
+  def notifyTerminOverview(cstate: CompilationState, data: Map[FunDef, Option[TerminationGuarantee]]) {
     if (cstate.isCompiled) {
-      val facts = for ((fd, tg) <- data) yield {
-        val t = toJson(Map(
-          "status" -> toJson(if (tg.isGuaranteed) "terminates" else "noguarantee")
-        ))
-
-        fd.id.name -> t
-      }
-
+      val facts = for ((fd, tg) <- data) yield (fd.id.name -> tgToJson(fd, tg))
       event("update_overview", Map("module" -> toJson("termination"), "overview" -> toJson(facts.toMap)))
     }
-
   }
 
   def receive = {
@@ -37,14 +50,21 @@ class TerminationWorker(val session: ActorRef, interruptManager: InterruptManage
 
       val program = cstate.program//.duplicate
 
+      // Notify the UI that the termination checker indeed will be launched now
+      val data = (cstate.functions.map { funDef =>
+         (funDef -> None)
+      }).toMap
+      notifyTerminOverview(cstate, data)
+
+      logInfo("Termination checker started...")
       try {
-        val tc = new SimpleTerminationChecker(ctx, cstate.program)
-        //val tc = new ComplexTerminationChecker(ctx, program)
-        //tc.initialize()
+        //val tc = new SimpleTerminationChecker(ctx, cstate.program)
+        val tc = new ComplexTerminationChecker(ctx, program)
 
         val data = (cstate.functions.map { funDef =>
-          (funDef -> tc.terminates(funDef))
+          (funDef -> Some(tc.terminates(funDef)))
         }).toMap
+        logInfo("Termination checker done.")
 
         notifyTerminOverview(cstate, data)
       } catch {
@@ -52,7 +72,7 @@ class TerminationWorker(val session: ActorRef, interruptManager: InterruptManage
           logInfo("[!] Termination crashed!", t)
 
           val data = (cstate.functions.map { funDef =>
-            (funDef -> NoGuarantee)
+            (funDef -> Some(NoGuarantee))
           }).toMap
 
           notifyTerminOverview(cstate, data)

--- a/public/leon.css
+++ b/public/leon.css
@@ -241,7 +241,7 @@ div.panel .table {
     padding-left: 30px;
 }
 
-#overview_table td.status.verif i {
+#overview_table td.status.verif i, #overview_table td.status.termin i {
     cursor: pointer;
 }
 
@@ -276,11 +276,11 @@ div#codebox.compilation-error div.ace_gutter-active-line {
 
 /* modals */
 
-#synthesisProgress, #verifyProgress {
+#synthesisProgress, #verifyProgress, #terminationProgress {
     height: 30px;
 }
 
-#synthesisProgress .progress-bar, #verifyProgress .progress-bar {
+#synthesisProgress .progress-bar, #verifyProgress .progress-bar, #terminationProgress .progress-bar {
     text-align: center;
     padding-top: 4px;
     text-shadow: 1px 1px 0 #000;
@@ -306,9 +306,11 @@ tr.counter-example table.input td {
     padding: 4px 1px;
     vertical-align: middle;
 }
+/*
 tr.counter-example table.input td:first-child {
     text-align: right;
 }
+*/
 
 /* Synthesis */
 


### PR DESCRIPTION
In the overview box, instead of only distinguishing between terminates / no guarantee, we now distinguish between terminates / conditionally terminates / loops / no guarantee. And clicking on the icon in the overview box opens a dialog with details, displaying the counterexample or the called non-terminating functions (if any).
