### PR TITLE
Fixed bug of termination not working on web interface.

### DIFF
--- a/app/workers/TerminationWorker.scala
+++ b/app/workers/TerminationWorker.scala
@@ -17,7 +17,8 @@ class TerminationWorker(s: ActorRef, im: InterruptManager) extends WorkerActor(s
   def tgToJson(fd: FunDef, tgo: Option[TerminationGuarantee]): JsValue = tgo match {
     case Some(tg) => tg match {
       case Terminates(reason) => toJson(Map(
-        "status" -> toJson(Status.terminates)
+        "status" -> toJson(Status.terminates),
+        "reason" -> toJson(reason)
       ))
       case LoopsGivenInputs(reason, args) => toJson(Map(
         "status" -> toJson(Status.loopsfor),
@@ -62,7 +63,7 @@ class TerminationWorker(s: ActorRef, im: InterruptManager) extends WorkerActor(s
         //val tc = new SimpleTerminationChecker(ctx, cstate.program)
         val tc = new ComplexTerminationChecker(ctx, program)
 
-        val data = (cstate.functions.map { funDef =>
+        val data = (tc.functions.map { funDef =>
           (funDef -> Some(tc.terminates(funDef)))
         }).toMap
         logInfo("Termination checker done.")

--- a/client/src/main/scala/leon/Handlers.scala
+++ b/client/src/main/scala/leon/Handlers.scala
@@ -147,6 +147,7 @@ object HandlersTypes {
   trait TerminationDetails extends js.Object with Status {
     val call: String
     val calls: js.Array[String]
+    val reason: js.UndefOr[String]
   }
   
   @ScalaJSDefined

--- a/client/src/main/scala/leon/Leon.scala
+++ b/client/src/main/scala/leon/Leon.scala
@@ -1006,7 +1006,7 @@ object Main {
       case TerminationStatus.terminates =>
         pbb.html("Terminates!")
         pbb.addClass("progress-bar-success")
-        tbl.append("""<tr class="success"> <td>This function terminates for all inputs.</td> </tr>""")
+        tbl.append("""<tr class="success"> <td>This function terminates for all inputs. ("""+fdata.reason.getOrElse("")+""")</td> </tr>""")
 
       case TerminationStatus.loopsfor =>
         pbb.html("Non-terminating!")


### PR DESCRIPTION
When looping over functions, Leon-web looped over the previous set of functions, not the new one generated by the termination checker.
Hence, it did not detect recursive loops anymore.
