### PR TITLE
Configure the path to the Git working copies in setup.conf

### DIFF
--- a/app/models/ConsoleSession.scala
+++ b/app/models/ConsoleSession.scala
@@ -27,6 +27,7 @@ import leon.utils.PreprocessingPhase
 
 import leon.web.workers._
 import leon.web.stores.PermalinkStore
+import leon.web.services.RepositoryService
 import leon.web.services.github._
 import leon.web.models.github.json._
 import leon.web.shared.{Action, Module}
@@ -255,7 +256,7 @@ class ConsoleSession(remoteIP: String, user: Option[User]) extends Actor with Ba
         clientLog(s"=> DONE")
 
         val (owner, name) = (repo.owner, repo.name)
-        val wc = new RepositoryInfos(s"${user.fullId}/$owner/$name", Some(token))
+        val wc = RepositoryService.repositoryFor(user, owner, name, Some(token))
 
         val progressActor = Akka.system.actorOf(Props(
           classOf[JGitProgressWorker],
@@ -285,7 +286,7 @@ class ConsoleSession(remoteIP: String, user: Option[User]) extends Actor with Ba
 
     case RepositoryLoaded(user, repo) =>
       val (owner, name) = (repo.owner, repo.name)
-      val wc = new RepositoryInfos(s"${user.fullId}/$owner/$name", None)
+      val wc = RepositoryService.repositoryFor(user, owner, name)
 
       clientLog(s"Listing files in '$owner/$name'...")
 
@@ -315,7 +316,7 @@ class ConsoleSession(remoteIP: String, user: Option[User]) extends Actor with Ba
 
       result onSuccess { case repo =>
         val (owner, name) = (repo.owner, repo.name)
-        val wc = new RepositoryInfos(s"${user.fullId}/$owner/$name")
+        val wc = RepositoryService.repositoryFor(user, owner, name)
 
         if (!wc.exists) {
           logInfo(s"Could not find a working copy for repository '$owner/$name'")
@@ -353,7 +354,7 @@ class ConsoleSession(remoteIP: String, user: Option[User]) extends Actor with Ba
 
       result onSuccess { case repo =>
         val (owner, name) = (repo.owner, repo.name)
-        val wc = new RepositoryInfos(s"${user.fullId}/$owner/$name")
+        val wc = RepositoryService.repositoryFor(user, owner, name)
 
         if (!wc.exists) {
           logInfo(s"Could not find a working copy for repository '$owner/$name'")

--- a/app/models/RepositoryInfos.scala
+++ b/app/models/RepositoryInfos.scala
@@ -31,7 +31,7 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
   *
   * @author Etienne Kneuss (etienne.kneuss@epfl.ch)
   */
-class RepositoryInfos(name: String, token: Option[String] = None) {
+class RepositoryInfos(val path: File, token: Option[String] = None) {
   import scala.collection.JavaConversions._
 
   case class Walker(tw: TreeWalk) {
@@ -44,10 +44,6 @@ class RepositoryInfos(name: String, token: Option[String] = None) {
 
       res.reverse
     }
-  }
-
-  lazy val path = {
-    new File("repositories/"+name)
   }
 
   lazy val repo = {

--- a/app/services/RepositoryService.scala
+++ b/app/services/RepositoryService.scala
@@ -1,0 +1,23 @@
+/* Copyright 2009-2015 EPFL, Lausanne */
+
+package leon.web
+package services
+
+import java.io.File
+import play.Play
+
+import leon.web.models.{User, RepositoryInfos}
+
+object RepositoryService {
+
+  lazy val root = {
+    Play.application.configuration.getString("repositories.path")
+  }
+
+  def repositoryFor(user: User, owner: String, name: String, token: Option[String] = None): RepositoryInfos = {
+    val path = new File(s"$root/${user.fullId}/$owner/$name")
+    new RepositoryInfos(path, token)
+  }
+
+}
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,6 +59,7 @@ assets.production.external.dir="./"
 http.port=9000
 auth.github.clientId=""
 auth.github.clientSecret=""
+repositories.path=""
 
 include "setup.conf"
 


### PR DESCRIPTION
This allows to store the working copies outside of the Play application, and in the same place regardless of whether the application runs in development of production mode.

Be sure to add the following line to `conf/setup.conf`:

```
repositories.path="/absolute/path/to/the/working/copies"
```
